### PR TITLE
Newspaper missing field

### DIFF
--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -37,7 +37,7 @@ defmodule SorinPrimo do
       "&apikey=#{Application.get_env(:sorin_primo, :api_key)}" <>
     (if (filters["item_type"] == "newspapers"), do:
       "&newspapersActive=true&newspapersSearch=true",
-	else: "" ) <>
+	else: "&newspapersActive=true&newspapersSearch=false" ) <>
       "&lang=#{Application.get_env(:sorin_primo, :lang)}" <>
       "&pcAvailability=false" <>
       "&offset=#{offset}" <>

--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -25,6 +25,7 @@ defmodule SorinPrimo do
       filters
       |> Enum.map(fn {k, v} -> parse_filter(k, v) end)
       |> Enum.filter(& !is_nil(&1))
+      |> Enum.filter(fn x -> x != "" end)
       |> Enum.join("%7C%2C%7C")
 
     response =

--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -61,12 +61,25 @@ defmodule SorinPrimo do
     %{num_results: num_results, results: results}
   end
 
+  defp parse(result) do
+    # If the result is either not a newspaper article or is one and
+    # has the right unique ID field for newspapers populated, passes
+    # the result to build_resource/1. Otherwise returns an empty map.
+    resource_type = result["pnx"]["display"]["type"] |> Enum.at(-1)
+    has_newspaper_id = result["pnx"]["control"]["addsrcrecordid"]
+    cond do
+      (resource_type != "newspaper_article") || has_newspaper_id ->
+	build_resource_map(result)
+      true -> %{}
+    end
+  end
+
   @doc """
   Maps fields from Primo's Brief Search API results to maps with the same
   fields as a Resource struct.
 
   """
-  def parse(result) do
+  def build_resource_map(result) do
     #
     # NOTE: "coverage", "relation", "direct_url", and "rights" are mapped to
     #       nil because they are not returned by Primo, but should be returned

--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -151,11 +151,9 @@ defmodule SorinPrimo do
     Jason.decode!(body)
   end
 
-  @doc """
-  Helper function for returning the last value in a specified field.
-
-  """
-  def parse_field(field) do
+  defp parse_field(field) do
+    # Primo returns most of its values wrapped up in a list; this
+    # function extracts the value we want from the list.
     if(field, do: field |> Enum.at(-1))
   end
 

--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -147,12 +147,7 @@ defmodule SorinPrimo do
     }
   end
 
-  @doc """
-  Helper function for parsing the JSON results of a Primo Brief Search API
-  request.
-
-  """
-  def handle_request({:ok, %{status_code: 200, body: body}}) do
+  defp handle_request({:ok, %{status_code: 200, body: body}}) do
     Jason.decode!(body)
   end
 

--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -74,21 +74,25 @@ defmodule SorinPrimo do
     end
   end
 
-  @doc """
-  Maps fields from Primo's Brief Search API results to maps with the same
-  fields as a Resource struct.
-
-  """
-  def build_resource_map(result) do
+  defp build_resource_map(result) do
+    # Extracts fields from Primo's Brief Search API results and uses them
+    # to construct a map formatted for rendering as a Core.Resources.Resource.
     #
-    # NOTE: "coverage", "relation", "direct_url", and "rights" are mapped to
-    #       nil because they are not returned by Primo, but should be returned
-    #       to the outer Search module to keep it generic.
+    # NOTES:
     #
-    #       "availability_status" and "sublocation" are mapped for display in
-    #       search results, but are not part of the Resource schema.
+    # - "coverage", "relation", "direct_url", and "rights" are mapped to nil
+    #   because although they are not returned by Primo, they should still be
+    #   returned in order to keep the outer Search module generic across
+    #   catalogs.
     #
-    doc_id =
+    # - "availability_status" and "sublocation" are returned for display in
+    #   search results for the convenience of end users, but are not part of
+    #   the Resource schema.
+    #
+    # - "identifier" and "catalog_url" have to be populated differently for
+    #   newspaper articles and all other resources.
+    #
+    identifier =
       case parse_field(result["pnx"]["display"]["type"]) do
 	"newspaper_article" ->
 	  "BM_" <> parse_field(result["pnx"]["control"]["addsrcrecordid"])
@@ -98,8 +102,8 @@ defmodule SorinPrimo do
     full_display =
       case parse_field(result["pnx"]["display"]["type"]) do
 	"newspaper_article" ->
-	  "npfulldisplay?docid=#{doc_id}"
-	_ -> "fulldisplay?docid=#{doc_id}"
+	  "npfulldisplay?docid=#{identifier}"
+	_ -> "fulldisplay?docid=#{identifier}"
       end
 
     catalog_url =
@@ -122,7 +126,7 @@ defmodule SorinPrimo do
       "doi"                 => parse_field(result["pnx"]["addata"]["doi"]),
       "ext_collection"      => parse_field(result["pnx"]["facets"]["collection"]),
       "format"              => parse_field(result["pnx"]["display"]["format"]),
-      "identifier"          => doc_id,
+      "identifier"          => identifier,
       "is_part_of"          => parse_field(result["pnx"]["display"]["ispartof"]),
       "issue"               => parse_field(result["pnx"]["addata"]["issue"]),
       "journal"             => parse_field(result["pnx"]["addata"]["jtitle"]),


### PR DESCRIPTION
These commits probably need no explanation beyond the commit messages, but briefly: this merge resolves a cluster of issues that arise when Primo returns a newspaper article that doesn't have the field we're using as the resource's unique ID. 

N.B.: there are other fields that can be used as a unique ID; we chose this particular field because we use it to construct a link back from Sorin to the resource's view in Primo.

This merge also makes all functions but search/4 private, and cleans up a little bit in general.