### PR TITLE
Convert encoding to www_form to better comply with what Primo likes

### DIFF
--- a/lib/sorin_primo.ex
+++ b/lib/sorin_primo.ex
@@ -19,7 +19,7 @@ defmodule SorinPrimo do
   """
   def search(search_string, limit, offset, filters) do
     encoded_search_string =
-      search_string |> String.trim() |> URI.encode()
+      search_string |> String.trim() |> URI.encode_www_form()
 
     parsed_filters =
       filters


### PR DESCRIPTION
User www_form encoding for the query string.